### PR TITLE
Remove superfluous maxdist-estimation message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sleepwalk
 Type: Package
 Title: Interactively Explore Dimension-Reduced Embeddings
-Version: 0.3.2
+Version: 0.3.2.9000
 Date: 2021-09-16
 Authors@R: c(
     person( "Svetlana", "Ovchinnikova", role=c("aut","cre"), 

--- a/R/sleepwalk.R
+++ b/R/sleepwalk.R
@@ -228,8 +228,7 @@ sleepwalk <- function( embeddings, featureMatrices = NULL, maxdists = NULL, poin
   if(is.null(maxdists)) {
     if(!is.null(featureMatrices)) {
       maxdists <- sapply(1:length(featureMatrices), function(i) {
-        message(paste0("Estimating 'maxdist' for feature matrix "), i)
-        pairs <- cbind(sample(nrow(featureMatrices[[i]]), 1500, TRUE), 
+        pairs <- cbind(sample(nrow(featureMatrices[[i]]), 1500, TRUE),
                        sample(nrow(featureMatrices[[i]]), 1500, TRUE))
         if(metric[i] == "euclid")  {
           median(sqrt(rowSums((featureMatrices[[i]][pairs[, 1], , drop = FALSE] - featureMatrices[[i]][pairs[, 2], , drop = FALSE])^2)))


### PR DESCRIPTION
## Summary
- Removes the `message("Estimating 'maxdist' for feature matrix ", i)` call printed once per feature matrix whenever `maxdists` isn't given explicitly (the common case) - purely internal progress noise with no bearing on the actual result.
- Bumped to a dev version (`0.3.2.9000`), same reasoning as the other open branches (#13, #14): `pak` and similar tools can key "already installed" on name+version alone.

Independent of #13 and #14 - branched off `master`.

## Test plan
- [x] Confirmed via `capture.output(..., type = "message")` around a `sleepwalk()` call with no `maxdists` given that zero messages are now printed, and that the resulting output/`maxdist` estimation still works (file still produced correctly).
- [x] `R CMD check` passes (Status: OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cHHuMa6d7mroK9qKLcSrC